### PR TITLE
Fix Invalid Prop Color in badges

### DIFF
--- a/components/AddByInput.js
+++ b/components/AddByInput.js
@@ -13,7 +13,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'45 LB'}
           number={plateNumbers.fortyFive}
-          bg={'plates.45'}
+          bg={'#0F52BA'}
           handleOnPress={() => handleOnPressBadges(45)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(45, plateNumbers.fortyFive)
@@ -25,7 +25,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'35 LB'}
           number={plateNumbers.thirtyFive}
-          bg={'plates.35'}
+          bg={'#FCF55F'}
           handleOnPress={() => handleOnPressBadges(35)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(55, plateNumbers.thirtyFive)
@@ -37,7 +37,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'25 LB'}
           number={plateNumbers.twentyFive}
-          bg={'plates.25'}
+          bg={'#009E60'}
           handleOnPress={() => handleOnPressBadges(25)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(25, plateNumbers.twentyFive)
@@ -50,7 +50,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'10 LB'}
           number={plateNumbers.ten}
-          bg={'plates.10'}
+          bg={'#FAF9F6'}
           handleOnPress={() => handleOnPressBadges(10)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(10, plateNumbers.ten)
@@ -63,7 +63,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'5 LB'}
           number={plateNumbers.five}
-          bg={'plates.5'}
+          bg={'#880808'}
           handleOnPress={() => handleOnPressBadges(5)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(5, plateNumbers.five)
@@ -76,7 +76,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'2.5 LB'}
           number={plateNumbers.twoPointFive}
-          bg={'plates.2'}
+          bg={'black'}
           handleOnPress={() => handleOnPressBadges(2.5)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(2.5, plateNumbers.twoPointFive)

--- a/components/AddByPlate.js
+++ b/components/AddByPlate.js
@@ -13,7 +13,7 @@ export default function AddByPlate({ plateNumbers }) {
         <PlateBadge
           text={'45 LB'}
           number={plateNumbers.fortyFive || 0}
-          bg={'plates.45'}
+          bg={'#0F52BA'}
           handleOnPress={() => handleOnPressBadges(45)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(45, plateNumbers.fortyFive)
@@ -24,7 +24,7 @@ export default function AddByPlate({ plateNumbers }) {
           <PlateBadge
             text={'35 LB'}
             number={plateNumbers.thirtyFive || 0}
-            bg={'plates.35'}
+            bg={'#FCF55F'}
             handleOnPress={() => handleOnPressBadges(35)}
             handleOnLongPress={() => handleOnLongPress(35)}
           />
@@ -33,7 +33,7 @@ export default function AddByPlate({ plateNumbers }) {
         <PlateBadge
           text={'25 LB'}
           number={plateNumbers.twentyFive || 0}
-          bg={'plates.25'}
+          bg={'#009E60'}
           handleOnPress={() => handleOnPressBadges(25)}
           handleOnLongPress={() => handleOnLongPressBadges(25)}
         />
@@ -41,7 +41,7 @@ export default function AddByPlate({ plateNumbers }) {
         <PlateBadge
           text={'10 LB'}
           number={plateNumbers.ten || 0}
-          bg={'plates.10'}
+          bg={'#FAF9F6'}
           handleOnPress={() => handleOnPressBadges(10)}
           handleOnLongPress={() => handleOnLongPressBadges(10)}
         />
@@ -49,7 +49,7 @@ export default function AddByPlate({ plateNumbers }) {
         <PlateBadge
           text={'5 LB'}
           number={plateNumbers.five || 0}
-          bg={'plates.5'}
+          bg={'#880808'}
           handleOnPress={() => handleOnPressBadges(5)}
           handleOnLongPress={() => handleOnLongPressBadges(5)}
         />
@@ -57,7 +57,7 @@ export default function AddByPlate({ plateNumbers }) {
         <PlateBadge
           text={'2.5 LB'}
           number={plateNumbers.twoPointFive || 0}
-          bg={'plates.2'}
+          bg={'black'}
           handleOnPress={() => handleOnPressBadges(2.5)}
           handleOnLongPress={() => handleOnLongPressBadges(2.5)}
         />

--- a/components/PlateBadge.js
+++ b/components/PlateBadge.js
@@ -9,16 +9,16 @@ export function PlateBadge({
   handleOnLongPress,
 }) {
   return (
-    <Center mr='5' mb='2'>
+    <Center mr="5" mb="2">
       <VStack>
         <Badge // bg="red.400"
-          colorScheme='danger'
-          rounded='999px'
+          colorScheme="danger"
+          rounded="999px"
           mb={-4}
           mr={-4}
           zIndex={1}
-          variant='solid'
-          alignSelf='flex-end'
+          variant="solid"
+          alignSelf="flex-end"
           _text={{
             fontSize: 12,
           }}
@@ -30,7 +30,7 @@ export function PlateBadge({
             base: 'auto',
             md: 0,
           }}
-          p='2'
+          p="2"
           bg={bg}
           _text={{
             fontSize: Dimensions.get('window').width > 375 ? 14 : 10,


### PR DESCRIPTION
Fix invalid prop badges. Currently hardcode badges.
Invariant Violation: Invalid prop `backgroundColor` supplied to `StyleSheet box`: twoPointFive
Valid color formats are...