### PR TITLE
Add badge colors to genPlateComponents fn

### DIFF
--- a/components/AddByInput.js
+++ b/components/AddByInput.js
@@ -6,6 +6,8 @@ import { PlateBadge } from './PlateBadge';
 export default function AddByInput({ plateNumbers }) {
   const { handleOnLongPressBadges, handleOnPressBadges } = useHomeContext();
 
+  const { colors } = plateNumbers;
+
   return (
     <View style={styles.plateNumberStyles}>
       {/* //Render 45lb plate */}
@@ -13,7 +15,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'45 LB'}
           number={plateNumbers.fortyFive}
-          bg={'#0F52BA'}
+          bg={colors.blue}
           handleOnPress={() => handleOnPressBadges(45)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(45, plateNumbers.fortyFive)
@@ -25,7 +27,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'35 LB'}
           number={plateNumbers.thirtyFive}
-          bg={'#FCF55F'}
+          bg={colors.yellow}
           handleOnPress={() => handleOnPressBadges(35)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(55, plateNumbers.thirtyFive)
@@ -37,7 +39,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'25 LB'}
           number={plateNumbers.twentyFive}
-          bg={'#009E60'}
+          bg={colors.green}
           handleOnPress={() => handleOnPressBadges(25)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(25, plateNumbers.twentyFive)
@@ -50,7 +52,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'10 LB'}
           number={plateNumbers.ten}
-          bg={'#FAF9F6'}
+          bg={colors.white}
           handleOnPress={() => handleOnPressBadges(10)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(10, plateNumbers.ten)
@@ -63,7 +65,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'5 LB'}
           number={plateNumbers.five}
-          bg={'#880808'}
+          bg={colors.red}
           handleOnPress={() => handleOnPressBadges(5)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(5, plateNumbers.five)
@@ -76,7 +78,7 @@ export default function AddByInput({ plateNumbers }) {
         <PlateBadge
           text={'2.5 LB'}
           number={plateNumbers.twoPointFive}
-          bg={'black'}
+          bg={colors.black}
           handleOnPress={() => handleOnPressBadges(2.5)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(2.5, plateNumbers.twoPointFive)

--- a/components/AddByPlate.js
+++ b/components/AddByPlate.js
@@ -7,13 +7,15 @@ export default function AddByPlate({ plateNumbers }) {
   const { thirtyFive, handleOnLongPressBadges, handleOnPressBadges } =
     useHomeContext();
 
+  const { colors } = plateNumbers;
+
   return (
     <View>
       <View style={styles.plateNumberStyles}>
         <PlateBadge
           text={'45 LB'}
           number={plateNumbers.fortyFive || 0}
-          bg={'#0F52BA'}
+          bg={colors.blue}
           handleOnPress={() => handleOnPressBadges(45)}
           handleOnLongPress={() =>
             handleOnLongPressBadges(45, plateNumbers.fortyFive)
@@ -24,7 +26,7 @@ export default function AddByPlate({ plateNumbers }) {
           <PlateBadge
             text={'35 LB'}
             number={plateNumbers.thirtyFive || 0}
-            bg={'#FCF55F'}
+            bg={colors.yellow}
             handleOnPress={() => handleOnPressBadges(35)}
             handleOnLongPress={() => handleOnLongPress(35)}
           />
@@ -33,7 +35,7 @@ export default function AddByPlate({ plateNumbers }) {
         <PlateBadge
           text={'25 LB'}
           number={plateNumbers.twentyFive || 0}
-          bg={'#009E60'}
+          bg={colors.green}
           handleOnPress={() => handleOnPressBadges(25)}
           handleOnLongPress={() => handleOnLongPressBadges(25)}
         />
@@ -41,7 +43,7 @@ export default function AddByPlate({ plateNumbers }) {
         <PlateBadge
           text={'10 LB'}
           number={plateNumbers.ten || 0}
-          bg={'#FAF9F6'}
+          bg={colors.white}
           handleOnPress={() => handleOnPressBadges(10)}
           handleOnLongPress={() => handleOnLongPressBadges(10)}
         />
@@ -49,7 +51,7 @@ export default function AddByPlate({ plateNumbers }) {
         <PlateBadge
           text={'5 LB'}
           number={plateNumbers.five || 0}
-          bg={'#880808'}
+          bg={colors.red}
           handleOnPress={() => handleOnPressBadges(5)}
           handleOnLongPress={() => handleOnLongPressBadges(5)}
         />
@@ -57,7 +59,7 @@ export default function AddByPlate({ plateNumbers }) {
         <PlateBadge
           text={'2.5 LB'}
           number={plateNumbers.twoPointFive || 0}
-          bg={'black'}
+          bg={colors.black}
           handleOnPress={() => handleOnPressBadges(2.5)}
           handleOnLongPress={() => handleOnLongPressBadges(2.5)}
         />

--- a/utilities/functions/functions.js
+++ b/utilities/functions/functions.js
@@ -49,7 +49,18 @@ export const genPlateComponents = (weight, thirtyFive, barWeight) => {
     weight = weight - 5;
   }
 
+  //Add plate numbers to an object at the end of the array
   plates.push(plateNumbers);
+
+  //Add an object of plate colors for badges in the object created above
+  plates[plates.length - 1]['colors'] = {
+    blue: '#0F52BA',
+    yellow: '#FCF55F',
+    green: '#009E60',
+    white: '#FAF9F6',
+    red: '#880808',
+    black: '#000000',
+  };
 
   return plates;
 };


### PR DESCRIPTION
Add the badge colors to the genPlateComponets fn.
This is a quick fix. Future update will refactor to be able to use color information for both plates and badges.